### PR TITLE
Update forum references

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -5,7 +5,7 @@ Here are few guidlines that should help you get started.
 
 == Using GitHub issues
 
-We use GitHub issues to track bugs and enhancements. You find a bug in the source code ? You want to propose new features or enhancements  You can help us by submitting an issue in our https://github.com/gravitee-io/gravitee-policy-request-validation[repository]. Before you submit your issue, search the https://github.com/gravitee-io/gravitee-policy-request-validation/issues[issues archive] or the https://waffle.io/gravitee-io/release[backlog]; maybe your question was already answered.
+We use GitHub issues to track bugs and enhancements. You find a bug in the source code ? You want to propose new features or enhancements  You can help us by submitting an issue in our https://github.com/gravitee-io/gravitee-policy-assign-content[repository]. Before you submit your issue, search the https://github.com/gravitee-io/issues/issues[issues repository]; maybe your question was already answered.
 
 > Issues are only to report bugs, request enhancements, or request new features. For general questions and discussions, use the https://groups.google.com/forum/#!forum/graviteeio[Gravitee.io Forum].
 


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-content/1.7.0/gravitee-policy-assign-content-1.7.0.zip)
  <!-- Version placeholder end -->
