### PR TITLE
Clean and validate json schema for v4

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,34 +1,38 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:assigncontent:configuration:AssignContentPolicyConfiguration",
-  "properties" : {
-    "scope" : {
-      "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> or <strong>response</strong> phase.",
-      "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE" ],
-      "deprecated": "true"
-    },
-    "body" : {
-      "title": "Body content",
-      "description": "The body content to attach to the request or to the response. You can also make use of freemarker templating engine to map an incoming body content to a new one.",
-      "type" : "string",
-      "x-schema-form": {
-        "type": "codemirror",
-        "codemirrorOptions": {
-          "placeholder": "Put the body content here",
-          "lineWrapping": true,
-          "lineNumbers": true,
-          "allowDropFileTypes": true,
-          "autoCloseTags": true,
-          "mode": "xml"
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "scope": {
+            "title": "Scope",
+            "description": "Select phase to execute the policy.",
+            "type": "string",
+            "default": "REQUEST",
+            "enum": ["REQUEST", "RESPONSE"],
+            "deprecated": "true"
+        },
+        "body": {
+            "title": "Body content",
+            "type": "string",
+            "format": "gio-code-editor",
+            "x-schema-form": {
+                "type": "codemirror",
+                "codemirrorOptions": {
+                    "placeholder": "Put the body content here",
+                    "lineWrapping": true,
+                    "lineNumbers": true,
+                    "allowDropFileTypes": true,
+                    "autoCloseTags": true,
+                    "mode": "xml"
+                }
+            },
+            "gioConfig": {
+                "banner": {
+                    "title": "Body content",
+                    "text": "The body content to attach to the request or to the response. You can also make use of freemarker templating engine to map an incoming body content to a new one."
+                }
+            }
         }
-      }
-    }
-  },
-  "required": [
-    "scope",
-    "body"
-  ]
+    },
+    "required": ["scope", "body"]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2085

**Description**
clean and validate json schema for v4


Tested with :
https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
https://particles.gravitee.io/?path=/story/components-form-json-schema--string

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-content/2.0.0-json-schema-SNAPSHOT/gravitee-policy-assign-content-2.0.0-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
