### PR TITLE
Archi 254 use new execution mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <gravitee-entrypoint-sse.version>3.1.0-alpha.2</gravitee-entrypoint-sse.version>
         <gravitee-entrypoint-http-post.version>1.0.0-alpha.2</gravitee-entrypoint-http-post.version>
-        <gravitee-reactor-message.version>1.0.0-alpha.7</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>1.0.0-alpha.10</gravitee-reactor-message.version>
 
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->

--- a/src/test/java/io/gravitee/policy/assigncontent/AssignContentPolicyV4IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/assigncontent/AssignContentPolicyV4IntegrationTest.java
@@ -24,12 +24,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
-import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.apim.gateway.tests.sdk.connector.fakes.MessageStorage;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
-import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.core.http.HttpClient;
@@ -44,10 +41,9 @@ import org.junit.jupiter.api.Test;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class AssignContentPolicyIntegrationTest {
+public class AssignContentPolicyV4IntegrationTest {
 
     @Nested
-    @GatewayTest(mode = GatewayMode.JUPITER)
     @DeployApi("/apis/v4/assign-content-proxy.json")
     class HttpProxy extends V4EngineTest {
 
@@ -86,7 +82,6 @@ public class AssignContentPolicyIntegrationTest {
     }
 
     @Nested
-    @GatewayTest(mode = GatewayMode.JUPITER)
     @DeployApi("/apis/v4/assign-content-message-subscription.json")
     class OnMessageResponse extends V4EngineTest {
 
@@ -118,7 +113,6 @@ public class AssignContentPolicyIntegrationTest {
     }
 
     @Nested
-    @GatewayTest(mode = GatewayMode.JUPITER)
     @DeployApi("/apis/v4/assign-content-message-publish.json")
     class OnMessageRequest extends V4EngineTest {
 

--- a/src/test/java/io/gravitee/policy/assigncontent/V4EngineTest.java
+++ b/src/test/java/io/gravitee/policy/assigncontent/V4EngineTest.java
@@ -19,6 +19,7 @@ import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactor
 import com.graviteesource.entrypoint.sse.SseEntrypointConnectorFactory;
 import com.graviteesource.reactor.message.MessageApiReactorFactory;
 import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.fakes.PersistentMockEndpointConnectorFactory;
@@ -37,6 +38,7 @@ import java.util.Set;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
+@GatewayTest
 public class V4EngineTest extends AbstractPolicyTest<AssignContentPolicy, AssignContentPolicyConfiguration> {
 
     @Override

--- a/src/test/java/io/gravitee/policy/v3/assigncontent/AssignContentPolicyV4EmulationEngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/assigncontent/AssignContentPolicyV4EmulationEngineIntegrationTest.java
@@ -26,7 +26,6 @@ import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
-import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.policy.assigncontent.AssignContentPolicy;
 import io.gravitee.policy.assigncontent.configuration.AssignContentPolicyConfiguration;
 import io.vertx.core.http.HttpMethod;
@@ -35,39 +34,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@GatewayTest(v2ExecutionMode = ExecutionMode.V3)
-@DeployApi("/apis/v3/assign-content.json")
-class AssignContentPolicyV3IntegrationTest extends AbstractPolicyTest<AssignContentPolicy, AssignContentPolicyConfiguration> {
-
-    @Test
-    @DisplayName("Should assign content, using Freemarker")
-    void shouldAssignContent(HttpClient client) throws Exception {
-        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend").withHeader("responseHeader", "responseHeaderValue")));
-
-        final var obs = client
-            .rxRequest(HttpMethod.GET, "/test")
-            .flatMap(request -> request.putHeader("requestHeader", "requestHeaderValue").rxSend())
-            .flatMapPublisher(response -> {
-                assertThat(response.statusCode()).isEqualTo(200);
-                return response.toFlowable();
-            })
-            .test();
-
-        obs.await();
-        obs
-            .assertComplete()
-            .assertValue(response -> {
-                assertThat(response.toString()).isEqualTo("Response body built from header 'responseHeader': responseHeaderValue");
-                return true;
-            })
-            .assertNoErrors();
-
-        wiremock.verify(
-            getRequestedFor(urlPathEqualTo("/endpoint"))
-                .withRequestBody(equalTo("Request body built from header 'requestHeader': requestHeaderValue"))
-        );
-    }
-}
+@GatewayTest
+class AssignContentPolicyV4EmulationEngineIntegrationTest extends AssignContentPolicyV3IntegrationTest {}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-254


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-archi-254-remove-jupiter-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-assign-content/2.0.0-archi-254-remove-jupiter-SNAPSHOT/gravitee-policy-assign-content-2.0.0-archi-254-remove-jupiter-SNAPSHOT.zip)
  <!-- Version placeholder end -->
